### PR TITLE
fixed bugs in steady state calculation and equilibrium conditions

### DIFF
--- a/initialization/eqcond990.m
+++ b/initialization/eqcond990.m
@@ -85,7 +85,7 @@ G1(nevol,qk_t) = zeta_nqk;
 G1(nevol,kbar_t) = zeta_nqk;
 G1(nevol,n_t) = zeta_nn;
 G1(nevol,R_t) = -zeta_nR;%BUG FIXED -- TERM ADDED ON 9/27/11
-G1(nevol,b_t) = -zeta_nR;
+G1(nevol,b_t) = -zeta_nR*(-(sigmac*(1+h*exp(-zstar)))/(1-h*exp(-zstar)));% BUG FIXED -- TERM NORMALIZED ON 9/15/16
 
 %%* flexible prices and wages - ASSUME NO FINANCIAL FRICTIONS
 G0(capval_f,E_rk_f) = -rkstar/(rkstar+1-del);
@@ -223,9 +223,10 @@ G0(msub_f,z_t) = h*exp(-zstar)/( 1-h*exp(-zstar) );
 G0(wage,w_t)    = 1;
 G0(wage,muw_t)  = (1-zeta_w*bet*exp((1-sigmac)*zstar))*(1-zeta_w)/(zeta_w*((law-1)*epsw+1))*1/(1+bet*exp((1-sigmac)*zstar));
 G0(wage,pi_t)   = (1+iota_w*bet*exp((1-sigmac)*zstar))*1/(1+bet*exp((1-sigmac)*zstar));
+G0(wage,z_t)    = (1+iota_w*bet*exp((1-sigmac)*zstar))*1/(1+bet*exp((1-sigmac)*zstar)); %BUG FIXED -- TERM CORRECTED ON 9/15/16
 G1(wage,w_t)    = 1/(1+bet*exp((1-sigmac)*zstar));
-G0(wage,z_t)    = 1/(1+bet*exp((1-sigmac)*zstar));
 G1(wage,pi_t)   = iota_w*1/(1+bet*exp((1-sigmac)*zstar));
+G1(wage,z_t)    = iota_w*1/(1+bet*exp((1-sigmac)*zstar)); %BUG FIXED -- TERM ADDED ON 9/15/16
 G0(wage,E_w)    = -bet*exp((1-sigmac)*zstar)*1/(1+bet*exp((1-sigmac)*zstar));
 %G0(wage,ztil_t) = -( 1/(1-alp) )*(rho_z-1)*bet*exp((1-sigmac)*zstar)*1/(1+bet*exp((1-sigmac)*zstar));
 G0(wage,E_z) = -bet*exp((1-sigmac)*zstar)*1/(1+bet*exp((1-sigmac)*zstar));

--- a/initialization/getpara00_990.m
+++ b/initialization/getpara00_990.m
@@ -130,7 +130,9 @@ rkstar = sprd*rstar*ups - (1-del);%NOTE: includes "sprd*"
 
 wstar = (alp^(alp)*(1-alp)^(1-alp)*rkstar^(-alp)/Bigphi)^(1/(1-alp));
 
-Lstar = 1;
+% Lstar = 1;
+Lstar = (wstar/law/((1-gstar)*(alp/(1-alp)*wstar/rkstar)^alp/Bigphi-...
+    (1-(1-del)/ups*exp(-zstar))*ups*exp(zstar)*alp/(1-alp)*wstar/rkstar)/(1-h*exp(-zstar)))^(1/(1+nu_l));
 
 kstar = (alp/(1-alp))*wstar*Lstar/rkstar;
 
@@ -177,13 +179,14 @@ nkstar = nkfcn(zwstar,sigwstar,sprd);
 Rhostar = 1/nkstar-1;
 
 % evaluate wekstar and vkstar
-wekstar = (1-gammstar/bet)*nkstar...
-    -gammstar/bet*(sprd*(1-muestar*Gstar)-1);
+betbar=bet*exp((1-sigmac)*zstar);
+wekstar = (1-gammstar/betbar)*nkstar...
+    -gammstar/betbar*(sprd*(1-muestar*Gstar)-1);
 vkstar = (nkstar-wekstar)/gammstar;
 
 % evaluate nstar and vstar
-nstar = nkstar*kstar;
-vstar = vkstar*kstar;
+nstar = nkstar*kbarstar;
+vstar = vkstar*kbarstar;
 
 % a couple of combinations
 GammamuG = Gammastar-muestar*Gstar;
@@ -204,7 +207,7 @@ zeta_zsigw = sigwstar*(dGammadsigmastar-muestar*dGdsigmastar)/GammamuG;
 zeta_spsigw = (zeta_bw_zw*zeta_zsigw-zeta_bsigw)/(1-zeta_bw_zw);
 
 % elasticities wrt mue
-zeta_bmue = muestar*(nkstar*dGammadomegastar*dGdomegastar/GammamuGprime+dGammadomegastar*Gstar*sprd)/...
+zeta_bmue = -muestar*(nkstar*dGammadomegastar*dGdomegastar/GammamuGprime+dGammadomegastar*Gstar*sprd)/...
     ((1-Gammastar)*GammamuGprime*sprd+dGammadomegastar*(1-nkstar));
 zeta_zmue = -muestar*Gstar/GammamuG;
 zeta_spmue = (zeta_bw_zw*zeta_zmue-zeta_bmue)/(1-zeta_bw_zw);
@@ -216,10 +219,10 @@ zeta_Gsigw = dGdsigmastar/Gstar*sigwstar;
 
 % elasticities for the net worth evolution
 zeta_nRk = gammstar*Rkstar/pistar/exp(zstar)*(1+Rhostar)*(1-muestar*Gstar*(1-zeta_Gw/zeta_zw));
-zeta_nR = gammstar/bet*(1+Rhostar)*(1-nkstar+muestar*Gstar*sprd*zeta_Gw/zeta_zw);
+zeta_nR = gammstar/betbar*(1+Rhostar)*(1-nkstar+muestar*Gstar*sprd*zeta_Gw/zeta_zw);
 zeta_nqk = gammstar*Rkstar/pistar/exp(zstar)*(1+Rhostar)*(1-muestar*Gstar*(1+zeta_Gw/zeta_zw/Rhostar))...
-    -gammstar/bet*(1+Rhostar);
-zeta_nn = gammstar/bet+gammstar*Rkstar/pistar/exp(zstar)*(1+Rhostar)*muestar*Gstar*zeta_Gw/zeta_zw/Rhostar;
+    -gammstar/betbar*(1+Rhostar);
+zeta_nn = gammstar/betbar+gammstar*Rkstar/pistar/exp(zstar)*(1+Rhostar)*muestar*Gstar*zeta_Gw/zeta_zw/Rhostar;
 zeta_nmue = gammstar*Rkstar/pistar/exp(zstar)*(1+Rhostar)*muestar*Gstar*(1-zeta_Gw*zeta_zmue/zeta_zw);
 zeta_nsigw = gammstar*Rkstar/pistar/exp(zstar)*(1+Rhostar)*muestar*Gstar*(zeta_Gsigw-zeta_Gw/zeta_zw*zeta_zsigw);
 


### PR DESCRIPTION
Hello,

I followed derivations of non-linear conditions and log-linearization of FRBNY model in sections 7 and 8 of the online technical appendix to Chapter 2 - DSGE Model-Based Forecasting in Handbook of Economic Forecasting, kindly made available [online](http://sites.sas.upenn.edu/schorf/files/hb_forecasting_appendix.pdf).

Below I explain a few bugs in the code which I found by replicating FRBNY model (version 990) using [IRIS toolbox](https://iristoolbox.codeplex.com/). [My IRIS code](https://github.com/ikarib/FRBNY-IRIS) replicates the impulse responses exactly (up to 10 digits after decimal point).

The are four bugs in steady state calculation (getpara00_990.m):

Bug #1: Labor can not be normalized to one (as in SW) since it violates FOC for labor in steady state.
Proof: This was mentioned in appendix (page 58) but not implemented in the code.

Bug #2: "bet" should be replaced by "betbar" in equation for wekstar, zeta_nR, zeta_nqk and zeta_nn
Proof: In sections 7.4 and 7.5, equations 7.25 and 7.44 assume log-utility (unlike section 8.1.2 where sigmac is not equal 1 and hence can not cancel out). Therefore in these equations "bet" should be replaced by
"betbar".

Bug #3: "kstar" should be replaced by "kbarstar" in equation for nstar and vstar
Proof: In the same equation 7.25, the ratios nkstar and wekstar are taken w.r.t. to kbarstar not kstar.

Bug #4: zeta_bmue should have a minus sign
Proof: zeta_bmue has a minus sign in equation 7.86 (as a typo zeta_b,x) and the whole expression on r.h.s. can be simplified to just "zeta_{b,mue}=1-\tilde{R}^k__/R__".

The are also two bugs in equilibrium conditions (eqcond990.m):

Bug #5: missing normalization of shock b_t in evolution of net worth
Proof: In equation 7.51 when adding shock -b_{t-1} after -R_{t-1}, the shock needs to normalized by -(sigmac_(1+h_exp(-zstar)))/(1-h*exp(-zstar)).

Bug #6: missing term z_{t-1} and incorrect coefficient for term z_t in Phillips curve for wages
Proof: If we take wage Phillips curve (equation 13 in SW) and replace pi_t with pi_t+z_t then we don't get the same equation as 8.106.

You can see the fixed code on [my forked version at GitHub](https://github.com/ikarib/DSGE-2015-Apr/commit/b9f61071caee1334fdae35b4c83163dcf004d542).
